### PR TITLE
Generate test cases from cookiecutter input

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,3 +39,36 @@ jobs:
         run: |
           cd test-component
           make golden-diff -e git_volume=
+  test-rendered-test-cases:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        add_golden:
+          - "n"
+          - "y"
+        test_cases:
+          - "defaults"
+          - "defaults foo"
+          - "foo bar"
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+    - uses: Gr1N/setup-poetry@v7
+    - uses: actions/cache@v3
+      with:
+        path: ~/.cache/pypoetry/virtualenvs
+        key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
+    - run: poetry install
+    - name: Run lints
+      run: |
+        make render -e cruft_extra_content='{"slug":"test-component","name":"test-component","add_golden":"${{matrix.add_golden}}","test_cases":"${{matrix.test_cases}}"}'
+        for t in ${{matrix.test_cases}}; do
+          test -f test-component/tests/${t}.yml
+        done
+    - name: Run golden-diff-all
+      if: ${{ matrix.add_golden == 'y' }}
+      run: |
+        cd test-component
+        make -j1 golden-diff-all -e git_volume=

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,6 +3,8 @@
   "slug": "the-component",
   "parameter_key": "{{ cookiecutter.slug.replace('-', '_') }}",
 
+  "test_cases": "defaults",
+
   "add_lib": "n",
   "add_pp": "n",
   "add_golden": "y",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,10 +1,35 @@
 import shutil
 
+from pathlib import Path
+
+import yaml
+
 create_lib = "{{ cookiecutter.add_lib }}" == "y"
 add_golden = "{{ cookiecutter.add_golden }}" == "y"
 
 if not create_lib:
     shutil.rmtree("lib")
+
+test_cases = "{{ cookiecutter.test_cases }}"
+
+tests_dir = Path("tests")
+tests_dir.mkdir(exist_ok=True)
+
+for case in test_cases.split(" "):
+    f = tests_dir / f"{case}.yml"
+    with open(f, "w", encoding="utf-8") as testf:
+        testf.write("# Overwrite parameters here\n\n# parameters: {...}\n")
+
+    g = (
+        tests_dir
+        / "golden"
+        / case
+        / "{{ cookiecutter.slug }}"
+        / "apps"
+        / "{{ cookiecutter.slug }}.yaml"
+    )
+    g.parent.mkdir(exist_ok=True, parents=True)
+    g.touch()
 
 if not add_golden:
     shutil.rmtree("tests/golden")

--- a/{{ cookiecutter.slug }}/.github/workflows/test.yaml
+++ b/{{ cookiecutter.slug }}/.github/workflows/test.yaml
@@ -1,3 +1,4 @@
+{%- set test_cases = cookiecutter.test_cases.split(" ") -%}
 name: Pull Request
 on:
   pull_request:
@@ -33,7 +34,9 @@ jobs:
     strategy:
       matrix:
         instance:
-          - defaults
+{%- for instance in test_cases %}
+          - {{ instance }}
+{%- endfor %}
 {%- endif %}
     defaults:
       run:
@@ -55,7 +58,9 @@ jobs:
     strategy:
       matrix:
         instance:
-          - defaults
+{%- for instance in test_cases %}
+          - {{ instance }}
+{%- endfor %}
 {%- endif %}
     defaults:
       run:

--- a/{{ cookiecutter.slug }}/Makefile.vars.mk
+++ b/{{ cookiecutter.slug }}/Makefile.vars.mk
@@ -1,3 +1,4 @@
+{%- set test_cases = cookiecutter.test_cases.split(" ") -%}
 # The component name is hard-coded from the template
 COMPONENT_NAME ?= {{ cookiecutter.slug }}
 
@@ -53,7 +54,7 @@ KUBENT_IMAGE    ?= docker.io/projectsyn/kubent:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 {%- endif %}
 
-instance ?= defaults
+instance ?= {{ test_cases[0] }}
 {%- if cookiecutter.add_matrix == "y" and cookiecutter.add_golden == "y" %}
-test_instances = tests/defaults.yml
+test_instances ={% for instance in test_cases %} tests/{{instance}}.yml{% endfor %}
 {%- endif %}

--- a/{{ cookiecutter.slug }}/tests/defaults.yml
+++ b/{{ cookiecutter.slug }}/tests/defaults.yml
@@ -1,3 +1,0 @@
-# Overwrite parameters here
-
-# parameters: {...}


### PR DESCRIPTION
We introduce a new cookiecutter input `test_cases` which is expected to be a string containing a whitespace-separated list of test case names.

The template will generate a test file `tests/<case>.yml`, and associated golden tests output for each case.

Note that the template currently doesn't prohibit users from rendering a component with multiple test cases but with matrix tests disabled.


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
