### PR TITLE
Add flag to enable/disable Go unit tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,9 @@ jobs:
         add_matrix:
           - "n"
           - "y"
+        add_go_unit:
+          - "n"
+          - "y"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -33,7 +36,7 @@ jobs:
           key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
       - run: poetry install
       - name: Run lint
-        run: make test -e cruft_extra_content='{"slug":"test-component","name":"test-component","add_lib":"${{matrix.add_lib}}","add_pp":"${{matrix.add_pp}}","add_golden":"${{matrix.add_golden}}","add_matrix":"${{matrix.add_matrix}}"}'
+        run: make test -e cruft_extra_content='{"slug":"test-component","name":"test-component","add_lib":"${{matrix.add_lib}}","add_pp":"${{matrix.add_pp}}","add_golden":"${{matrix.add_golden}}","add_matrix":"${{matrix.add_matrix}}","add_go_unit":"${{matrix.add_go_unit}}"}'
       - name: Run golden-diff
         if: ${{ matrix.add_golden == 'y' }}
         run: |

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,6 +9,7 @@
   "add_pp": "n",
   "add_golden": "y",
   "add_matrix": "y",
+  "add_go_unit": "n",
 
   "copyright_holder": "VSHN AG <info@vshn.ch>",
   "copyright_year": "1950",

--- a/{{ cookiecutter.slug }}/.github/workflows/test.yaml
+++ b/{{ cookiecutter.slug }}/.github/workflows/test.yaml
@@ -46,6 +46,19 @@ jobs:
         with:
           path: {% raw %}${{ env.COMPONENT_NAME }}{% endraw %}
       - name: Compile component
+{%-  if cookiecutter.add_go_unit == "y" %}
+      - name: Determine Go version from go.mod
+        run: echo "GO_VERSION=$(grep "go 1." tests/go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
+      - uses: actions/setup-go@v3
+        with:
+          go-version: {% raw %}${{ env.GO_VERSION }}{% endraw %}
+      - uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: {% raw %}${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}{% endraw %}
+          restore-keys: |
+            {% raw %}${{ runner.os }}-go-{% endraw %}
+{%- endif %}
 {%-  if cookiecutter.add_matrix == "y" %}
         run: make test -e instance={% raw %}${{ matrix.instance }}{% endraw %}
 {%- else %}

--- a/{{ cookiecutter.slug }}/Makefile
+++ b/{{ cookiecutter.slug }}/Makefile
@@ -54,6 +54,11 @@ docs-serve: ## Preview the documentation
 .PHONY: test
 test: commodore_args += -f tests/$(instance).yml
 test: .compile ## Compile the component
+{%- if cookiecutter.add_go_unit %}
+	@echo
+	@echo
+	@cd tests && go test -count 1 ./...
+{% endif %}
 
 {%- if cookiecutter.add_golden == "y" %}
 .PHONY: gen-golden


### PR DESCRIPTION
The flag only controls the contents of the GitHub action and the Makefile. The template doesn't provide a Go unit test template and `make test` will fail out of the box for a component which has Go unit tests enabled but no tests defined.

See https://github.com/projectsyn/component-keycloak for an example component which uses Go unit tests.

This feature is primarily intended to ensure that existing components which use Go unit tests can be cleanly updated from the template.


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
