### PR TITLE
Use upstream `kubent` container image

### DIFF
--- a/{{ cookiecutter.slug }}/Makefile.vars.mk
+++ b/{{ cookiecutter.slug }}/Makefile.vars.mk
@@ -49,8 +49,7 @@ GOLDEN_FILES    ?= $(shell find tests/golden/$(instance) -type f)
 
 KUBENT_FILES    ?= $(shell echo "$(GOLDEN_FILES)" | sed 's/ /,/g')
 KUBENT_ARGS     ?= -c=false --helm2=false --helm3=false -e
-# Use our own kubent image until the upstream image is available
-KUBENT_IMAGE    ?= docker.io/projectsyn/kubent:latest
+KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 {%- endif %}
 


### PR DESCRIPTION
There's now official `kubent` images available from https://github.com/doitintl/kube-no-trouble/pkgs/container/kube-no-trouble.

This commit switches the component template to use that image instead of the one-off image we built ourselves.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
