### PR TITLE
Clean up golden tests `.editorconfig` section

### DIFF
--- a/{{ cookiecutter.slug }}/.editorconfig
+++ b/{{ cookiecutter.slug }}/.editorconfig
@@ -26,7 +26,7 @@ insert_final_newline = false
 indent_style = tab
 {%- if cookiecutter.add_golden == "y" %}
 
-; Ignore generated files
+; Ignore golden test outputs
 [tests/golden/**]
 indent_style = unset
 indent_size = unset

--- a/{{ cookiecutter.slug }}/.editorconfig
+++ b/{{ cookiecutter.slug }}/.editorconfig
@@ -28,8 +28,8 @@ indent_style = tab
 
 ; Ignore golden test outputs
 [tests/golden/**]
-indent_style = unset
 indent_size = unset
+indent_style = unset
 insert_final_newline = unset
 trim_trailing_whitespace = unset
 {%- endif %}


### PR DESCRIPTION
Follow up to #26 and the partial revert in https://github.com/projectsyn/commodore-component-template/commit/31ba1044d6952012b8015d6bc6bd950900d20453

At this point, all onboarded components should be in a state where the changes from this PR will apply cleanly.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
