### PR TITLE
Update PR checklist to clarify expectations

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,13 @@
 
 ## Checklist
 
+- [ ] The PR has a meaningful title. It will be used to auto generate the
+      changelog.
+      The PR has a meaningful description that sums up the change. It will be
+      linked in the changelog.
 - [ ] PR contains a single logical change (to build a better changelog).
-- [ ] Categorize the PR by setting a good title and adding one of the labels:
+- [ ] Update the documentation.
+- [ ] Categorize the PR by adding one of the labels:
       `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
       as they show up in the changelog.
 - [ ] Link this PR to related issues or PRs.

--- a/{{ cookiecutter.slug }}/.github/PULL_REQUEST_TEMPLATE.md
+++ b/{{ cookiecutter.slug }}/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,9 +3,13 @@
 
 ## Checklist
 
+- [ ] The PR has a meaningful title. It will be used to auto generate the
+      changelog.
+      The PR has a meaningful description that sums up the change. It will be
+      linked in the changelog.
 - [ ] PR contains a single logical change (to build a better changelog).
 - [ ] Update the documentation.
-- [ ] Categorize the PR by setting a good title and adding one of the labels:
+- [ ] Categorize the PR by adding one of the labels:
       `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
       as they show up in the changelog.
 - [ ] Link this PR to related issues or PRs.


### PR DESCRIPTION
This will adjust the checklist in the PR template to contain more context and expectations how a PR should be presented before it's review ready.

As discussed in https://github.com/vshn/component-appcat/pull/77

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
