### PR TITLE
Update kubent args for latest version of kubent

### DIFF
--- a/{{ cookiecutter.slug }}/Makefile.vars.mk
+++ b/{{ cookiecutter.slug }}/Makefile.vars.mk
@@ -48,7 +48,7 @@ JB_CMD         ?= $(DOCKER_CMD) $(DOCKER_ARGS) --entrypoint /usr/local/bin/jb do
 GOLDEN_FILES    ?= $(shell find tests/golden/$(instance) -type f)
 
 KUBENT_FILES    ?= $(shell echo "$(GOLDEN_FILES)" | sed 's/ /,/g')
-KUBENT_ARGS     ?= -c=false --helm2=false --helm3=false -e
+KUBENT_ARGS     ?= -c=false --helm3=false -e
 KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 {%- endif %}


### PR DESCRIPTION
See https://github.com/doitintl/kube-no-trouble/releases/tag/0.7.0

Unless we have #35, users which have a copy of kubent:latest which reports itself as 0.6.0, will have to manually update their image with `docker pull`.


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
