### PR TITLE
Ignore `.github` in Renovate config

### DIFF
--- a/{{ cookiecutter.slug }}/renovate.json
+++ b/{{ cookiecutter.slug }}/renovate.json
@@ -4,6 +4,9 @@
     ":gitSignOff",
     ":disableDependencyDashboard"
   ],
+  "ignorePaths": [
+    ".github/**"
+  ],
 {%- if cookiecutter.add_golden == "y" %}
   "postUpgradeTasks": {
     "commands": [


### PR DESCRIPTION
This should ensure that we don't get Renovate PRs on each component from the hosted Renovate instance for GitHub actions which we manage through the component template anyway.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
