### PR TITLE
Allow customizing patch automerge behavior for selected dependencies

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -14,6 +14,8 @@
   "automerge_patch": "y",
   "automerge_patch_v0": "n",
 
+  "automerge_patch_regexp_blocklist": "",
+
   "copyright_holder": "VSHN AG <info@vshn.ch>",
   "copyright_year": "1950",
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -15,6 +15,7 @@
   "automerge_patch_v0": "n",
 
   "automerge_patch_regexp_blocklist": "",
+  "automerge_patch_v0_regexp_allowlist": "",
 
   "copyright_holder": "VSHN AG <info@vshn.ch>",
   "copyright_year": "1950",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -74,10 +74,14 @@ if add_golden:
 # We always add an empty package rules list
 renovatejson["packageRules"] = []
 
-if automerge_patch:
-    # automerge patch PRs
-    patch_rule = {
-        "matchUpdateTypes": ["patch"],
+
+def rule_defaults(updateTypes, extraLabels=[]):
+    """Returns a dict containing a base package rule configuration for automerging.
+
+    By default automerging is disabled for dependencies whose current version matches `^v?0\.`
+    """
+    return {
+        "matchUpdateTypes": updateTypes,
         # negative match: do not match versions that match regex `^v?0\.`
         "matchCurrentVersion": "!/^v?0\\./",
         "automerge": True,
@@ -87,10 +91,16 @@ if automerge_patch:
         "platformAutomerge": False,
         # NOTE: We need to add all the labels we want here, renovate doesn't inherit globally
         # specified labels for package rules
-        "labels": ["dependency", "automerge"],
+        "labels": ["dependency", "automerge"] + extraLabels,
     }
+
+
+# automerge patch PRs if `automerge_patch` is True
+if automerge_patch:
+    patch_rule = rule_defaults(["patch"])
     if automerge_patch_v0:
-        # remove match current version if we want v0.x patch automerge
+        # If automerging patch updates for v0.x dependencies is enabled, remove field
+        # `matchCurrentVersion`
         del patch_rule["matchCurrentVersion"]
 
     # Set excludePackagePatterns to the provided list of package patterns for which patch PRs
@@ -112,20 +122,12 @@ if automerge_patch:
 # be automerged in cookiecutter argument `automerge_patch_regexp_blocklist`.
 if not automerge_patch_v0 and len(automerge_patch_v0_regexp_allowlist) > 0:
     patterns = automerge_patch_v0_regexp_allowlist.split(";")
-    patch_v0_rule = {
-        "matchUpdateTypes": ["patch"],
-        # only apply for packages whose current version matches `v?0\.`
-        "matchCurrentVersion": "/^v?0\\./",
-        "automerge": True,
-        # NOTE: We can't use Platform Automerge because the repositories are configured manually,
-        # so we can't be sure the "require status checks" option is always enabled, and without
-        # that, platformAutomerge does not wait for tests to pass.
-        "platformAutomerge": False,
-        # NOTE: We need to add all the labels we want here, renovate doesn't inherit globally
-        # specified labels for package rules
-        "labels": ["dependency", "automerge"],
-        "matchPackagePatterns": patterns,
-    }
+
+    patch_v0_rule = rule_defaults(["patch"])
+    # only apply for packages whose current version matches `v?0\.`
+    patch_v0_rule["matchCurrentVersion"] = "/^v?0\\./"
+    patch_v0_rule["matchPackagePatterns"] = patterns
+
     renovatejson["packageRules"].append(patch_v0_rule)
 
 # NOTE: Later rules in `packageRules` take precedence

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -12,6 +12,8 @@ add_matrix = "{{ cookiecutter.add_matrix }}" == "y"
 automerge_patch = "{{ cookiecutter.automerge_patch }}" == "y"
 automerge_patch_v0 = "{{ cookiecutter.automerge_patch_v0 }}" == "y"
 
+automerge_patch_regexp_blocklist = "{{ cookiecutter.automerge_patch_regexp_blocklist }}"
+
 if not create_lib:
     shutil.rmtree("lib")
 
@@ -87,6 +89,13 @@ if automerge_patch:
     if automerge_patch_v0:
         # remove match current version if we want v0.x patch automerge
         del patch_rule["matchCurrentVersion"]
+
+    # Set excludePackagePatterns to the provided list of package patterns for which patch PRs
+    # shouldn't be automerged. Only set the field if the provided list isn't empty.
+    if len(automerge_patch_regexp_blocklist) > 0:
+        # NOTE: We expect that the provided pattern list is a string with patterns separated by ;
+        patterns = automerge_patch_regexp_blocklist.split(";")
+        patch_rule["excludePackagePatterns"] = patterns
 
     renovatejson["packageRules"].append(patch_rule)
 


### PR DESCRIPTION
This PR introduces a new cookiecutter argument which allows users to specify zero or more regex patterns for dependencies whose patch level updates shouldn't be automerged.

The template expects that the contents of the new argument is a string which contains zero or more regex patterns separated by semicolons. The template will use these patterns as the values for the package rule field `excludePackagePatterns`.

Additionally, this PR introduces a new cookiecutter argument`automerge_patch_v0_regexp_allowlist` which can be used to selectively enable patch automerging for v0.x dependencies.

The template expects that the content of the new argument is a string which contains zero or more regexp patterns separated by semicolons.

If global automerging of patch updates for v0.x dependencies is disabled, but `automerge_patch_v0_regexp_allowlist` isn't empty, the template generates an additional package rule that enables automerge only for dependencies that are currently v0.x and which match one of the patterns provided in the argument.

This package rule is not required and therefore not generated when `automerge_patch_v0` is enabled. If you want to disable automerging for some v0.x patch level updates but automerge patch level updates for v0.x dependencies by default, you can specify patterns for which no patch level updates should be merged in cookiecutter argument `automerge_patch_regexp_blocklist`.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
