### PR TITLE
Allow enabling minor automerge based on patterns

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -16,6 +16,7 @@
 
   "automerge_patch_regexp_blocklist": "",
   "automerge_patch_v0_regexp_allowlist": "",
+  "automerge_minor_regexp_allowlist": "",
 
   "copyright_holder": "VSHN AG <info@vshn.ch>",
   "copyright_year": "1950",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -16,6 +16,7 @@ automerge_patch_regexp_blocklist = "{{ cookiecutter.automerge_patch_regexp_block
 automerge_patch_v0_regexp_allowlist = (
     "{{ cookiecutter.automerge_patch_v0_regexp_allowlist }}"
 )
+automerge_minor_regexp_allowlist = "{{ cookiecutter.automerge_minor_regexp_allowlist }}"
 
 if not create_lib:
     shutil.rmtree("lib")
@@ -129,6 +130,15 @@ if not automerge_patch_v0 and len(automerge_patch_v0_regexp_allowlist) > 0:
     patch_v0_rule["matchPackagePatterns"] = patterns
 
     renovatejson["packageRules"].append(patch_v0_rule)
+
+if len(automerge_minor_regexp_allowlist) > 0:
+    # NOTE: We expect that the provided pattern list is a string with patterns separated by ;
+    patterns = automerge_minor_regexp_allowlist.split(";")
+    minor_rule = rule_defaults(["minor"])
+    # Don't exclude dependencies whose current version is v0.x from minor automerge
+    del minor_rule["matchCurrentVersion"]
+    minor_rule["matchPackagePatterns"] = patterns
+    renovatejson["packageRules"].append(minor_rule)
 
 # NOTE: Later rules in `packageRules` take precedence
 


### PR DESCRIPTION
This commit introduces a new cookiecutter argument which is expected to hold zero or more patterns matching dependencies whose minor level updates should be automerged.

The template expects that the new argument is a string which contains zero or more regex patterns separated by semicolons. The resulting list of patterns is used in field `matchPackagePatterns` of a new package rule that enables automerge for minor updates.

The template will never enable minor level automerge for dependencies if their current version is `v0.x`.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
