### PR TITLE
Support for auto-releasing components

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -18,6 +18,8 @@
   "automerge_patch_v0_regexp_allowlist": "",
   "automerge_minor_regexp_allowlist": "",
 
+  "auto_release": "y",
+
   "copyright_holder": "VSHN AG <info@vshn.ch>",
   "copyright_year": "1950",
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -18,6 +18,8 @@ automerge_patch_v0_regexp_allowlist = (
 )
 automerge_minor_regexp_allowlist = "{{ cookiecutter.automerge_minor_regexp_allowlist }}"
 
+auto_release = "{{ cookiecutter.auto_release }}" == "y"
+
 if not create_lib:
     shutil.rmtree("lib")
 
@@ -98,7 +100,7 @@ def rule_defaults(updateTypes, extraLabels=[]):
 
 # automerge patch PRs if `automerge_patch` is True
 if automerge_patch:
-    patch_rule = rule_defaults(["patch"])
+    patch_rule = rule_defaults(["patch"], ["bump:patch"])
     if automerge_patch_v0:
         # If automerging patch updates for v0.x dependencies is enabled, remove field
         # `matchCurrentVersion`
@@ -124,7 +126,7 @@ if automerge_patch:
 if not automerge_patch_v0 and len(automerge_patch_v0_regexp_allowlist) > 0:
     patterns = automerge_patch_v0_regexp_allowlist.split(";")
 
-    patch_v0_rule = rule_defaults(["patch"])
+    patch_v0_rule = rule_defaults(["patch"], ["bump:patch"])
     # only apply for packages whose current version matches `v?0\.`
     patch_v0_rule["matchCurrentVersion"] = "/^v?0\\./"
     patch_v0_rule["matchPackagePatterns"] = patterns
@@ -134,7 +136,7 @@ if not automerge_patch_v0 and len(automerge_patch_v0_regexp_allowlist) > 0:
 if len(automerge_minor_regexp_allowlist) > 0:
     # NOTE: We expect that the provided pattern list is a string with patterns separated by ;
     patterns = automerge_minor_regexp_allowlist.split(";")
-    minor_rule = rule_defaults(["minor"])
+    minor_rule = rule_defaults(["minor"], ["bump:minor"])
     # Don't exclude dependencies whose current version is v0.x from minor automerge
     del minor_rule["matchCurrentVersion"]
     minor_rule["matchPackagePatterns"] = patterns
@@ -148,3 +150,7 @@ with open("renovate.json", "w", encoding="utf-8") as f:
 
 if Path(".sync.yml").is_file():
     os.unlink(Path(".sync.yml"))
+
+# remove auto-release workflow if not enabled
+if not auto_release:
+    os.unlink(Path(".github/workflows/auto-release.yaml"))

--- a/{{ cookiecutter.slug }}/.github/workflows/auto-release.yaml
+++ b/{{ cookiecutter.slug }}/.github/workflows/auto-release.yaml
@@ -1,4 +1,3 @@
-{%- raw -%}
 name: Autorelease
 on:
   pull_request:
@@ -17,4 +16,3 @@ jobs:
         with:
           trigger: |
             Release
-{% endraw -%}

--- a/{{ cookiecutter.slug }}/.github/workflows/auto-release.yaml
+++ b/{{ cookiecutter.slug }}/.github/workflows/auto-release.yaml
@@ -1,0 +1,20 @@
+{%- raw -%}
+name: Autorelease
+on:
+  pull_request:
+    types:
+      - synchronize
+      - labeled
+      - unlabeled
+      - closed
+
+jobs:
+  create-release-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create new tag
+        uses: projectsyn/pr-label-tag-action@v1
+        with:
+          trigger: |
+            Release
+{% endraw -%}

--- a/{{ cookiecutter.slug }}/.github/workflows/release.yaml
+++ b/{{ cookiecutter.slug }}/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - v*
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Create a new separate workflow that uses https://github.com/projectsyn/pr-label-tag-action to trigger the release workflow. Set the required labels in the renovate package rules for automerging.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
