### PR TITLE
Fix reading of `spec.project` in `appPath`

### DIFF
--- a/{{ cookiecutter.slug }}/component/app.jsonnet
+++ b/{{ cookiecutter.slug }}/component/app.jsonnet
@@ -6,7 +6,7 @@ local argocd = import 'lib/argocd.libjsonnet';
 local app = argocd.App('{{ cookiecutter.slug }}', params.namespace);
 
 local appPath =
-  local project = std.get(app, 'spec', { project: 'syn' }).project;
+  local project = std.get(std.get(app, 'spec', {}), 'project', 'syn');
   if project == 'syn' then 'apps' else 'apps-%s' % project;
 
 {


### PR DESCRIPTION
We need to use `std.get()` to read both `spec` and `spec.project` of the rendered application manifest, so that the template code works unchanged for components that customize `spec` of the rendered application.

Follow-up for #134 


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
